### PR TITLE
Fix Segfault on Ruby 2.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,5 @@ language: ruby
 rvm:
   - 1.9.3
   - 2.0.0
+  - 2.1.0
   - jruby-19mode

--- a/lib/delayed/plugins/honeybadger.rb
+++ b/lib/delayed/plugins/honeybadger.rb
@@ -1,34 +1,24 @@
 module Delayed
   module Plugins
     class Honeybadger < Plugin
-      module Notify
-        def error(job, error)
-          ::Honeybadger.notify_or_ignore(
-            :error_class   => error.class.name,
-            :error_message => "#{ error.class.name }: #{ error.message }",
-            :backtrace => error.backtrace,
-            :context       => {
-              :job_id => job.id,
-              :handler => job.handler,
-              :last_error => job.last_error,
-              :attempts => job.attempts,
-              :queue => job.queue
-            }
-          )
-          super if defined?(super)
-        end
-      end
-
       callbacks do |lifecycle|
-        lifecycle.before(:invoke_job) do |job|
-          payload = job.payload_object
-          payload = payload.object if payload.is_a? Delayed::PerformableMethod
-          payload.extend Notify
-        end
-
-        lifecycle.around(:perform) do |worker, &block|
+        lifecycle.around(:invoke_job) do |job, *args, &block|
           begin
-            block.call(worker)
+            block.call(job, *args)
+          rescue Exception => error
+            ::Honeybadger.notify_or_ignore(
+              :error_class   => error.class.name,
+              :error_message => "#{ error.class.name }: #{ error.message }",
+              :backtrace     => error.backtrace,
+              :context       => {
+                :job_id        => job.id,
+                :handler       => job.handler,
+                :last_error    => job.last_error,
+                :attempts      => job.attempts,
+                :queue         => job.queue
+              }
+            )
+            raise error
           ensure
             ::Honeybadger.context.clear!
           end


### PR DESCRIPTION
Inspired by this fix: https://github.com/rollbar/rollbar-gem/commit/ae36b448b5b3cf16aec64c3db24ccafc93371638

We were getting segfaults running in production under 2.1.0.

You can reproduce the segfault by running the specs for this gem under 2.1.0. 

This fixes it under 2.1.0, and specs still pass for 2.0.0 and 1.9.3. This also adds 2.1.0 to the .travis.yml.
